### PR TITLE
CRC 16 DNP Bugfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ PublishScripts/
 # NuGet v3's project.json files produces more ignoreable files
 *.nuget.props
 *.nuget.targets
+**/nuget.config
 
 # Microsoft Azure Build Output
 csx/

--- a/NullFX.CRC.Tests/Crc16Tests.cs
+++ b/NullFX.CRC.Tests/Crc16Tests.cs
@@ -40,7 +40,7 @@ namespace NullFX.CRC.Tests {
         static ushort CrcCcittFCrc = 0xF7B6;
 
         static ushort Crc16Standard_StartLessThanLength = 0x29D8;
-        static ushort Crc16Dnp_StartLessThanLength = 0xF23F;
+        static ushort Crc16Dnp_StartLessThanLength = 0x9B9A;
         static ushort Crc16CcittKermit_StartLessThanLength = 0x3579;
         static ushort Crc16Ccitt_StartLessThanLength = 0xC35B;
         static ushort Crc16Ccitt1D04_StartLessThanLength = 0x3295;

--- a/NullFX.CRC/Crc16.cs
+++ b/NullFX.CRC/Crc16.cs
@@ -57,11 +57,12 @@ namespace NullFX.CRC {
                 if ( bytes == null ) { throw new ArgumentNullException ( nameof ( bytes ) ); }
                 if ( bytes.Length == 0 ) { throw new ArgumentOutOfRangeException ( nameof ( bytes.Length ) ); }
                 if ( start < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
-                if ( start + length > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
-                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( start >= bytes.Length && length > 1 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
                 var crc = InitialValue;
-                var end = start + length;
-                for ( int i = start; i < end; ++i ) {
+                var end = start + length - 1;
+                if ( end > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                for ( int i = start; i <= end; ++i ) {
                     crc = ( ushort )( ( crc >> 8 ) ^ table[( byte )( crc ^ bytes[i] )] );
                 }
                 return crc;
@@ -95,11 +96,12 @@ namespace NullFX.CRC {
                 if ( bytes == null ) { throw new ArgumentNullException ( nameof ( bytes ) ); }
                 if ( bytes.Length == 0 ) { throw new ArgumentOutOfRangeException ( nameof ( bytes.Length ) ); }
                 if ( start < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
-                if ( start + length > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
-                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( start >= bytes.Length && length > 1 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
                 var crc = InitialValue;
-                var end = start + length;
-                for ( int i = start; i < end; ++i ) {
+                var end = start + length - 1;
+                if ( end > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                for ( int i = start; i <= end; ++i ) {
                     crc = ( ushort )( ( crc >> 8 ) ^ table[( byte )( crc ^ bytes[i] )] );
                 }
                 return crc.ByteSwapCompliment ( );
@@ -133,11 +135,12 @@ namespace NullFX.CRC {
                 if ( bytes == null ) { throw new ArgumentNullException ( nameof ( bytes ) ); }
                 if ( bytes.Length == 0 ) { throw new ArgumentOutOfRangeException ( nameof ( bytes.Length ) ); }
                 if ( start < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
-                if ( start + length > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
-                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( start >= bytes.Length && length > 1 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
                 var crc = InitialValue;
-                var end = start + length;
-                for ( int i = start; i < end; ++i ) {
+                var end = start + length - 1;
+                if ( end > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                for ( int i = start; i <= end; ++i ) {
                     crc = ( ushort )( ( crc >> 8 ) ^ table[( byte )( crc ^ bytes[i] )] );
                 }
                 return crc.ByteSwap ( );
@@ -233,11 +236,12 @@ namespace NullFX.CRC {
                 if ( bytes == null ) { throw new ArgumentNullException ( nameof ( bytes ) ); }
                 if ( bytes.Length == 0 ) { throw new ArgumentOutOfRangeException ( nameof ( bytes.Length ) ); }
                 if ( start < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
-                if ( start + length > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
-                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( start >= bytes.Length && length > 1 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
                 var crc = initialValue;
-                var end = start + length;
-                for ( int i = start; i < end; ++i ) {
+                var end = start + length - 1;
+                if ( end > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+                for ( int i = start; i <= end; ++i ) {
                     crc = ( ushort )( ( crc << 8 ) ^ Table[( ( crc >> 8 ) ^ ( 0xff & bytes[i] ) )] );
                 }
                 return crc;
@@ -275,7 +279,7 @@ namespace NullFX.CRC {
                 case Crc16Algorithm.CcittInitialValue0x1D0F:
                 return CcittInitial0x1D0F.ComputeChecksum ( bytes, start, length );
                 case Crc16Algorithm.Dnp:
-                return Dnp.ComputeChecksum ( bytes );
+                return Dnp.ComputeChecksum ( bytes, start, length );
             }
             throw new UnknownAlgorithmException ( "Unknown Algorithm" );
         }

--- a/NullFX.CRC/Crc32.cs
+++ b/NullFX.CRC/Crc32.cs
@@ -54,11 +54,12 @@ namespace NullFX.CRC {
             if ( bytes == null ) { throw new ArgumentNullException ( nameof ( bytes ) ); }
             if ( bytes.Length == 0 ) { throw new ArgumentOutOfRangeException ( nameof ( bytes.Length ) ); }
             if ( start < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
-            if ( start + length > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
-            if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+            if ( start >= bytes.Length && length > 1 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
             var crc = InitialValue;
-            var end = start + length;
-            for ( int i = start; i < end; ++i ) {
+            var end = start + length - 1;
+            if ( end > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+            if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+            for ( int i = start; i <= end; ++i ) {
                 crc = ( uint )( ( crc >> 8 ) ^ table[( byte )( ( ( crc ) & 0xff ) ^ bytes[i] )] );
             }
             return ~crc;

--- a/NullFX.CRC/Crc8.cs
+++ b/NullFX.CRC/Crc8.cs
@@ -53,11 +53,12 @@ namespace NullFX.CRC {
             if ( bytes == null ) { throw new ArgumentNullException ( nameof ( bytes ) ); }
             if ( bytes.Length == 0 ) { throw new ArgumentOutOfRangeException ( nameof ( bytes.Length ) ); }
             if ( start < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
-            if ( start + length > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
-            if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+            if ( start >= bytes.Length && length > 1 ) { throw new ArgumentOutOfRangeException ( nameof ( start ) ); }
             var crc = InitialValue;
-            var end = start + length;
-            for ( int i = start; i < end; ++i ) {
+            var end = start + length - 1;
+            if ( end > bytes.Length ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+            if ( length < 0 ) { throw new ArgumentOutOfRangeException ( nameof ( length ) ); }
+            for ( int i = start; i <= end; ++i ) {
                 crc = table[crc ^ bytes[i]];
             }
             return crc;

--- a/NullFX.CRC/NullFX.CRC.csproj
+++ b/NullFX.CRC/NullFX.CRC.csproj
@@ -12,17 +12,17 @@
     <PackageTags>CRC8 CRC16 CRC32</PackageTags>
     <PackageProjectUrl>https://github.com/nullfx/NullFX.CRC</PackageProjectUrl>
     <RepositoryUrl>https://github.com/nullfx/NullFX.CRC</RepositoryUrl>
-    <PackageVersion>1.1.0</PackageVersion>
+    <PackageVersion>1.1.1</PackageVersion>
     <Owners>Steve Whitley</Owners>
-    <Summary>A collection of common CRC algorithms implemented in .NET</Summary>
+    <Summary>NullFX CRC is a small set of CRC utilities (crc8, crc16, and crc32) written in C# and released under the MIT License</Summary>
     <Title>NullFX CRC</Title>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=nullfx_NullFX.CRC
 sonar.organization=nullfx
 sonar.projectName=NullFX.CRC
-sonar.projectVersion=1.1.0
+sonar.projectVersion=1.1.1
 sonar.sources=./NullFX.CRC
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
fixed CRC 16 DNP which was missing `start` and `length` somehow and therefore not calculating correct values ever outside of full crc calculations (discovered this while updating the swift version of this library). Fixed the CRC 16 Segment validation tests. Updated Assembly, sonar and package versions'
[range-bugfix2 784d8d2] fixed CRC 16 DNP which was missing `start` and `length` somehow and therefore not calculating correct values ever outside of full crc calculations (discovered this while updating the swift version of this library). Fixed the CRC 16 Segment validation tests. Updated Assembly, sonar and package versions