### PR TITLE
Benchmarks

### DIFF
--- a/NullFX.CRC.Benchmarks/HashGenerationBenchmark.cs
+++ b/NullFX.CRC.Benchmarks/HashGenerationBenchmark.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Data.HashFunction.CRC;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using NullFX.CRC;
+
+namespace NullFX.CRC.Benchmarks
+{
+	public class HashGenerationBenchmark
+	{
+		public const int Seed = 1337;
+		
+		[Params(10, 100, 1000)]
+		public int ArraySize { get; set; }
+
+		private byte[] data;
+
+		private ICRC crc8Provider;
+		private ICRC crc16Provider;
+		private ICRC crc32Provider;
+
+		[GlobalSetup]
+		public void PrepareBenchmark()
+		{
+			data = new byte[ArraySize];
+			Random rnd = new Random(Seed);
+			rnd.NextBytes(data);
+			
+			crc8Provider = CRCFactory.Instance.Create(CRCConfig.CRC8);
+			crc16Provider = CRCFactory.Instance.Create(CRCConfig.CRC16_USB);
+			crc32Provider = CRCFactory.Instance.Create(CRCConfig.CRC32);
+		}
+		
+		[Benchmark]
+		public byte NullFxCrc8()
+		{
+			var hash = NullFX.CRC.Crc8.ComputeChecksum(data, 0, ArraySize);
+			return hash;
+		}
+
+		[Benchmark]
+		public ushort NullFxCrc16()
+		{
+			var hash = NullFX.CRC.Crc16.ComputeChecksum(Crc16Algorithm.Standard, data, 0, ArraySize);
+			return hash;
+		}
+		
+		[Benchmark]
+		public uint NullFxCrc32()
+		{
+			var hash = NullFX.CRC.Crc32.ComputeChecksum(data, 0, ArraySize);
+			return hash;
+		}
+
+		[Benchmark]
+		public byte[] DataHashFunctionCrc8()
+		{
+			var hash = crc8Provider.ComputeHash(data);
+			return hash.Hash;
+		}
+		
+		[Benchmark]
+		public byte[] DataHashFunctionCrc16()
+		{
+			var hash = crc16Provider.ComputeHash(data);
+			return hash.Hash;
+		}
+		
+		[Benchmark]
+		public byte[] DataHashFunctionCrc32()
+		{
+			var hash = crc32Provider.ComputeHash(data);
+			return hash.Hash;
+		}
+	}
+}

--- a/NullFX.CRC.Benchmarks/NullFX.CRC.Benchmarks.csproj
+++ b/NullFX.CRC.Benchmarks/NullFX.CRC.Benchmarks.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>netcoreapp3.1</TargetFramework>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\NullFX.CRC\NullFX.CRC.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/NullFX.CRC.Benchmarks/NullFX.CRC.Benchmarks.csproj
+++ b/NullFX.CRC.Benchmarks/NullFX.CRC.Benchmarks.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
       <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+      <PackageReference Include="System.Data.HashFunction.CRC" Version="2.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NullFX.CRC.Benchmarks/Program.cs
+++ b/NullFX.CRC.Benchmarks/Program.cs
@@ -1,0 +1,12 @@
+﻿using BenchmarkDotNet.Running;
+
+namespace NullFX.CRC.Benchmarks
+{
+	internal static class Program
+	{
+		static void Main(string[] args)
+		{
+			BenchmarkRunner.Run<HashGenerationBenchmark>();
+		}
+	}
+}

--- a/NullFX.CRC.sln
+++ b/NullFX.CRC.sln
@@ -13,6 +13,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NullFX.CRC.Benchmarks", "NullFX.CRC.Benchmarks\NullFX.CRC.Benchmarks.csproj", "{9504D6B6-ED27-446C-A568-BB63BAD14C88}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{330036FA-2257-41F2-8B9C-0713FFD1880A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{330036FA-2257-41F2-8B9C-0713FFD1880A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{330036FA-2257-41F2-8B9C-0713FFD1880A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9504D6B6-ED27-446C-A568-BB63BAD14C88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9504D6B6-ED27-446C-A568-BB63BAD14C88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9504D6B6-ED27-446C-A568-BB63BAD14C88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9504D6B6-ED27-446C-A568-BB63BAD14C88}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Not sure if this is wanted, but I added a benchmark project to show the performance difference between this repo and [System.Data.HashFunction.CRC](https://www.nuget.org/packages/System.Data.HashFunction.CRC/).

The benchmark uses benchmarkdotnet and shows the performance difference pretty clearly.
As a side node, I also compared the hashing to dotnets Sha1 implementation and was quite surprised to see that SHA1 was faster for byte arrays with 1000+ elements.

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.100
  [Host]     : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT
  DefaultJob : .NET Core 3.1.9 (CoreCLR 4.700.20.47201, CoreFX 4.700.20.47203), X64 RyuJIT


```
|                Method | ArraySize |        Mean |     Error |    StdDev |
|---------------------- |---------- |------------:|----------:|----------:|
|            **NullFxCrc8** |        **10** |    **11.01 ns** |  **0.007 ns** |  **0.005 ns** |
|           NullFxCrc16 |        10 |    18.00 ns |  0.056 ns |  0.049 ns |
|           NullFxCrc32 |        10 |    14.62 ns |  0.105 ns |  0.098 ns |
|  DataHashFunctionCrc8 |        10 |   280.75 ns |  2.186 ns |  1.826 ns |
| DataHashFunctionCrc16 |        10 |   288.43 ns |  2.228 ns |  1.975 ns |
| DataHashFunctionCrc32 |        10 |   295.67 ns |  1.915 ns |  1.791 ns |
|            **NullFxCrc8** |       **100** |   **153.90 ns** |  **0.131 ns** |  **0.123 ns** |
|           NullFxCrc16 |       100 |   234.53 ns |  0.060 ns |  0.053 ns |
|           NullFxCrc32 |       100 |   206.83 ns |  0.701 ns |  0.585 ns |
|  DataHashFunctionCrc8 |       100 |   873.70 ns |  7.588 ns |  6.727 ns |
| DataHashFunctionCrc16 |       100 |   853.45 ns |  3.031 ns |  2.836 ns |
| DataHashFunctionCrc32 |       100 |   859.91 ns |  3.014 ns |  2.672 ns |
|            **NullFxCrc8** |      **1000** | **1,657.32 ns** |  **0.363 ns** |  **0.321 ns** |
|           NullFxCrc16 |      1000 | 2,411.69 ns |  0.269 ns |  0.238 ns |
|           NullFxCrc32 |      1000 | 2,157.53 ns |  0.213 ns |  0.189 ns |
|  DataHashFunctionCrc8 |      1000 | 7,344.52 ns | 42.928 ns | 40.155 ns |
| DataHashFunctionCrc16 |      1000 | 6,515.40 ns | 47.882 ns | 42.446 ns |
| DataHashFunctionCrc32 |      1000 | 6,687.30 ns | 91.290 ns | 85.392 ns |
